### PR TITLE
Stop badge commit when coverage didn't change

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add badges/interrogate_badge.svg
-        git commit -m "Update interrogate_badge.svg" -a
+        git diff --exit-code || git commit -m "Update interrogate_badge.svg" -a
 
     - name: Push changes
       if: success()


### PR DESCRIPTION
This action was failing for me when coverage percent was identical with the following error.

```
Run git config --local user.email "action@github.com"
  git config --local user.email "action@github.com"
  git config --local user.name "GitHub Action"
  git add badges/interrogate_badge.svg
  git commit -m "Update interrogate_badge.svg" -a
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.12/x64/lib
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
Error: Process completed with exit code 1.
```