### PR TITLE
Feat: Adds ignore-module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Fail when coverage % is less than a given amount.
 
 **Default**: `80`
 
+### ignore-module (optional)
+
+Ignore module-level docstrings when running `interrogate`.
+
+**Default**: `False`
+
 <!-- 
 ### exclude (optional)
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Fail when coverage % is less than a given amount.
 
 **Default**: `80`
 
-### ignore-module (optional)
-
-Ignore module-level docstrings when running `interrogate`.
-
-**Default**: `False`
-
 <!-- 
 ### exclude (optional)
 
@@ -44,6 +38,13 @@ Ignore `__init__.py` modules.
 Generate a `shields.io` status badge (an SVG image) in at a given file or directory.
 
 **Default**: `.`
+
+### ignore-module (optional)
+
+Ignore module-level docstrings when running `interrogate`.
+
+**Default**: `False`
+
 
 ## Example usage
 

--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: 'Fail when coverage % is less than a given amount.'
     required: false
     default: '80'
+  ignore-module:
+    description: 'Ignore module-level docstrings'
+    required: false
+    default: false
   # exclude:
   #   description: 'Exclude PATHs of files and/or directories.'
   #   required: false
@@ -41,3 +45,4 @@ runs:
     # - ${{ inputs.ignore-init-method }}
     # - ${{ inputs.ignore-init-module }}
     - ${{ inputs.badge-location }}
+    - ${{ inputs.ignore-module }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,13 @@ set -eax
 
 interrogate --version
 
+
+IGNORE_MODULE=$([[ "$4" == true ]] && echo '-M' || echo '')
+
 if interrogate --fail-under $2 --generate-badge $3 $1 | grep -q 'PASSED'; then
-    interrogate --fail-under $2 --generate-badge $3 $1
+    interrogate --fail-under $2 --generate-badge $3 $IGNORE_MODULE $1
     exit 0
 else 
-    interrogate --fail-under $2 --generate-badge $3 $1
+    interrogate --fail-under $2 --generate-badge $3 $IGNORE_MODULE $1
     exit 1
 fi


### PR DESCRIPTION
This PR adds the `ignore-module` option to the `python-interrogate-check` GitHub action, such that users can choose to ignore module level docstrings when generating the interrogate coverage for their project.
